### PR TITLE
Add IP address hashing

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,15 @@ To scrub IP addresses, use:
 Logstop.guard(logger, ip: true)
 ```
 
+In case you want to preserve the connection between log entries,
+you can anonymize IP addresses via hashing
+(like the [ip_anonymizer](https://github.com/ankane/ip_anonymizer) gem).
+Just add a key (e.g. via ```SecureRandom.hex(32)```):
+
+```ruby
+Logstop.guard(logger, ip: true, key: "random_key")
+```
+
 Add extra rules with: [master]
 
 ```ruby

--- a/lib/logstop/formatter.rb
+++ b/lib/logstop/formatter.rb
@@ -2,14 +2,15 @@ require "logger"
 
 module Logstop
   class Formatter < ::Logger::Formatter
-    def initialize(formatter = nil, ip: false, extra_rules: [])
+    def initialize(formatter = nil, ip: false, key: nil, extra_rules: [])
       @formatter = formatter || ::Logger::Formatter.new
       @ip = ip
+      @key = key
       @extra_rules = extra_rules
     end
 
     def call(severity, timestamp, progname, msg)
-      Logstop.scrub(@formatter.call(severity, timestamp, progname, msg), ip: @ip, extra_rules: @extra_rules)
+      Logstop.scrub(@formatter.call(severity, timestamp, progname, msg), ip: @ip, key: @key, extra_rules: @extra_rules)
     end
 
     # for tagged logging

--- a/test/logstop_test.rb
+++ b/test/logstop_test.rb
@@ -39,6 +39,11 @@ class LogstopTest < Minitest::Test
     assert_equal "[FILTERED]", Logstop.scrub("test@test.com")
   end
 
+  def test_scrub_with_key
+    assert_equal 'Started GET "/" for 131.76.35.185 at 2018-11-27 14:09:23 +0100',
+                 Logstop.scrub('Started GET "/" for 8.9.10.42 at 2018-11-27 14:09:23 +0100', ip: true, key: "1234567890")
+  end
+
   def test_scrub_nil
     assert_equal "", Logstop.scrub(nil)
   end


### PR DESCRIPTION
I needed to keep logfiles for a longer time period, but without the real IP addresses. Your ip_anonymizer gem looked great, but I could not integrate it directly to anonymize the IP addresses in the Rails logs. So I added the hashing function from the ip_anonymizer gem to this gem.

Of course I could also adding the masking method here, but I don't need it currently and I didn't want to copy more methods from your other gem.