### PR TITLE
Scrub Active Record attributes by names

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,11 +41,13 @@ Logstop.guard(logger)
 
 ### Rails
 
-Create `config/initializers/logstop.rb` with:
+Generate the default configuration file into `config/initializers/logstop.rb` directory with:
 
 ```ruby
-Logstop.guard(Rails.logger)
+rails generate logstop:config
 ```
+
+Use this file with options below.
 
 ## Options
 
@@ -54,6 +56,14 @@ To scrub IP addresses, use:
 ```ruby
 Logstop.guard(logger, ip: true)
 ```
+
+To scrub Active Record attributes, use:
+
+```ruby
+Logstop.guard(logger, active_record: true)
+```
+
+and list their names using `Logstop.configure` method in `logstop` initializer.
 
 Add custom rules with:
 

--- a/lib/generators/config_generator.rb
+++ b/lib/generators/config_generator.rb
@@ -1,0 +1,14 @@
+require "rails/generators"
+
+module Logstop
+	module Generators
+		class ConfigGenerator < Rails::Generators::Base
+			source_root File.expand_path("templates", __dir__)
+
+			# Generates default Logstop configuration file into your application config/initializers directory.
+			def copy_config_file
+				copy_file "logstop_config.rb", "config/initializers/logstop.rb"
+			end
+		end
+	end
+end

--- a/lib/generators/config_generator.rb
+++ b/lib/generators/config_generator.rb
@@ -1,14 +1,14 @@
 require "rails/generators"
 
 module Logstop
-	module Generators
-		class ConfigGenerator < Rails::Generators::Base
-			source_root File.expand_path("templates", __dir__)
+  module Generators
+    class ConfigGenerator < Rails::Generators::Base
+      source_root File.expand_path("templates", __dir__)
 
-			# Generates default Logstop configuration file into your application config/initializers directory.
-			def copy_config_file
-				copy_file "logstop_config.rb", "config/initializers/logstop.rb"
-			end
-		end
-	end
+      # Generates default Logstop configuration file into your application config/initializers directory.
+      def copy_config_file
+        copy_file "logstop_config.rb", "config/initializers/logstop.rb"
+      end
+    end
+  end
 end

--- a/lib/generators/templates/logstop_config.rb
+++ b/lib/generators/templates/logstop_config.rb
@@ -1,0 +1,3 @@
+Logstop.configure do |config|
+	config.scrub_attributes = %w[]
+end

--- a/lib/generators/templates/logstop_config.rb
+++ b/lib/generators/templates/logstop_config.rb
@@ -1,5 +1,5 @@
 Logstop.configure do |config|
-	config.scrub_attributes = %w[]
+  config.scrub_attributes = %w[]
 end
 
 Logstop.guard(Rails.logger)

--- a/lib/generators/templates/logstop_config.rb
+++ b/lib/generators/templates/logstop_config.rb
@@ -1,3 +1,5 @@
 Logstop.configure do |config|
 	config.scrub_attributes = %w[]
 end
+
+Logstop.guard(Rails.logger)

--- a/lib/logstop.rb
+++ b/lib/logstop.rb
@@ -37,25 +37,25 @@ module Logstop
   def self.guard(logger, **options)
     logger.formatter = Logstop::Formatter.new(logger.formatter, **options)
   end
-	
+  
   def self.scrub_attributes(msg)
-		Logstop.config.scrub_attributes.each do |attribute_name|
-			next if attribute_scrubbed?(msg, attribute_name)
-	
-			msg.gsub!(attribute_regex(attribute_name), filtered_attribute_str(attribute_name))
-		end
-		msg
-	end
-	
-	def self.attribute_scrubbed?(msg, attribute_name)
-		msg.include? filtered_attribute_str(attribute_name)
-	end
-	
-	def self.attribute_regex(attribute_name)
-		/\["#{attribute_name}", [^\[,]*/
-	end
-	
-	def self.filtered_attribute_str(attribute_name)
-		"[\"#{attribute_name}\", \"#{FILTERED_STR}\"]"
-	end
+    Logstop.config.scrub_attributes.each do |attribute_name|
+      next if attribute_scrubbed?(msg, attribute_name)
+  
+      msg.gsub!(attribute_regex(attribute_name), filtered_attribute_str(attribute_name))
+    end
+    msg
+  end
+  
+  def self.attribute_scrubbed?(msg, attribute_name)
+    msg.include? filtered_attribute_str(attribute_name)
+  end
+  
+  def self.attribute_regex(attribute_name)
+    /\["#{attribute_name}", [^\[,]*/
+  end
+  
+  def self.filtered_attribute_str(attribute_name)
+    "[\"#{attribute_name}\", \"#{FILTERED_STR}\"]"
+  end
 end

--- a/lib/logstop.rb
+++ b/lib/logstop.rb
@@ -27,7 +27,7 @@ module Logstop
     msg.gsub!(SSN_REGEX, FILTERED_STR)
 
     msg.gsub!(IP_REGEX, FILTERED_STR) if ip
-    scrub_active_record_attributes(msg) if active_record
+    scrub_attributes(msg) if active_record
 
     msg = scrubber.call(msg) if scrubber
 
@@ -38,7 +38,7 @@ module Logstop
     logger.formatter = Logstop::Formatter.new(logger.formatter, **options)
   end
 	
-  def self.scrub_active_record_attributes(msg)
+  def self.scrub_attributes(msg)
 		Logstop.config.scrub_attributes.each do |attribute_name|
 			next if attribute_scrubbed?(msg, attribute_name)
 	

--- a/lib/logstop/config.rb
+++ b/lib/logstop/config.rb
@@ -1,0 +1,19 @@
+module Logstop
+	class << self
+		def configure
+			yield config
+		end
+
+		def config
+			@config ||= Config.new
+		end
+	end
+
+	class Config
+		attr_accessor :scrub_attributes
+
+		def initialize
+			@scrub_attributes = scrub_attributes
+		end
+	end
+end

--- a/lib/logstop/config.rb
+++ b/lib/logstop/config.rb
@@ -1,19 +1,19 @@
 module Logstop
-	class << self
-		def configure
-			yield config
-		end
+  class << self
+    def configure
+      yield config
+    end
 
-		def config
-			@config ||= Config.new
-		end
-	end
+    def config
+      @config ||= Config.new
+    end
+  end
 
-	class Config
-		attr_accessor :scrub_attributes
+  class Config
+    attr_accessor :scrub_attributes
 
-		def initialize
-			@scrub_attributes = scrub_attributes
-		end
-	end
+    def initialize
+      @scrub_attributes = scrub_attributes
+    end
+  end
 end

--- a/lib/logstop/formatter.rb
+++ b/lib/logstop/formatter.rb
@@ -5,8 +5,8 @@ module Logstop
     def initialize(formatter = nil, ip: false, scrubber: nil, active_record: false)
       @formatter = formatter || ::Logger::Formatter.new
       @ip = ip
-			@scrubber = scrubber
-			@active_record = active_record
+      @scrubber = scrubber
+      @active_record = active_record
     end
 
     def call(severity, timestamp, progname, msg)

--- a/lib/logstop/formatter.rb
+++ b/lib/logstop/formatter.rb
@@ -2,14 +2,15 @@ require "logger"
 
 module Logstop
   class Formatter < ::Logger::Formatter
-    def initialize(formatter = nil, ip: false, scrubber: nil)
+    def initialize(formatter = nil, ip: false, scrubber: nil, active_record: false)
       @formatter = formatter || ::Logger::Formatter.new
       @ip = ip
-      @scrubber = scrubber
+			@scrubber = scrubber
+			@active_record = active_record
     end
 
     def call(severity, timestamp, progname, msg)
-      Logstop.scrub(@formatter.call(severity, timestamp, progname, msg), ip: @ip, scrubber: @scrubber)
+      Logstop.scrub(@formatter.call(severity, timestamp, progname, msg), ip: @ip, scrubber: @scrubber, active_record: @active_record)
     end
 
     # for tagged logging


### PR DESCRIPTION
# Enhancement

Closes: https://github.com/ankane/logstop/issues/8

## Description

When using `logstop` in Rails and willing to scrub some Active Record attributes from query logs, run this generator:

```ruby
rails generate config:logstop
```

override `scrub_attributes` and enable `active_record` option in `guard` method e.g.:

```ruby
Logstop.configure do |config|
  config.scrub_attributes = %w[week_date]
end

Logstop.guard(Rails.logger, active_record: true)
```

Output:

<img width="1439" alt="Screenshot 2021-01-03 at 14 48 49" src="https://user-images.githubusercontent.com/13117305/103480252-80d7da00-4dd3-11eb-8181-0047664f3f68.png">

## Why should this be added

Add an option of filtering Active Record query logs by passing attribute names.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] Tests are written and passing

