### PR TITLE
group performance and test related gems in groups

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,9 @@ source "https://rubygems.org"
 gemspec
 
 gem "activesupport"
-gem "benchmark-ips"
-gem "memory_profiler"
-gem "minitest"
+group(:development, :test) do
+  gem "benchmark-ips"
+  gem "memory_profiler"
+  gem "minitest"
+end
 gem "rake"


### PR DESCRIPTION
In order to avoid having unnecessary dependencies installed in environment that don't need them this patch adds groups in the Gemfile.

While Benchmark and memory profiler gems could be handy in some cases in staging envs in my opinion it's rare to do so.
The minitest gem is obviously for test.