### PR TITLE
Use `respond_to_missing?` instead of `respond_to?`

### DIFF
--- a/lib/logstop/formatter.rb
+++ b/lib/logstop/formatter.rb
@@ -34,8 +34,8 @@ module Logstop
     end
 
     # for tagged logging
-    def respond_to?(method_name, include_private = false)
-      @formatter.send(:respond_to?, method_name, include_private) || super
+    def respond_to_missing?(method_name, include_private = false)
+      @formatter.respond_to?(method_name, include_private) || super
     end
   end
 end


### PR DESCRIPTION
It's considered best practice since ruby 1.9.2 to define a `respond_to_missing?` method instead of just a `respond_to?` when you have a `method_missing` method defined. Small update here to do that!